### PR TITLE
Boost - joystream recipe to download source from download.joystream.co

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
   include:
     - os: linux
       dist: trusty
+      # requiring sudo will trigger builds to run on a dedicated VM, which has more
+      # RAM. This is required for building boost from source successfully.
       sudo: required
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,19 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      sudo: false
+      sudo: required
+      addons:
+        apt:
+          sources:
+            - george-edison55-precise-backports
+          packages:
+            - cmake
+            - cmake-data
+            - rpm
+            - fakeroot
     - os: osx
       osx_image: xcode7.3
       sudo: false
-
-addons:
-  apt:
-    sources:
-      - george-edison55-precise-backports
-    packages:
-      - cmake
-      - cmake-data
-  apt:
-    packages:
-    - fakeroot
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" = osx ]]; then

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class JoyStreamNode(ConanFile):
                 "ProtocolStateMachine/0.3.0@joystream/stable",
                 "ProtocolSession/0.3.0@joystream/stable",
                 "Extension/0.3.0@joystream/stable",
-                "Boost/1.60.0@lasote/stable",
+                "Boost/1.60.0@joystream/stable",
                 "OpenSSL/1.0.2j@lasote/stable")
 
     generators = "cmake"


### PR DESCRIPTION
Updated to use joystream recipe: https://bintray.com/joystream/joystream/Boost:joystream/1.60.0:stable

Which will download boost source files from `download.joystream.co` server